### PR TITLE
Add placeholder pages for the new site nav

### DIFF
--- a/_pages/cloud-gov-federalist.md
+++ b/_pages/cloud-gov-federalist.md
@@ -1,0 +1,168 @@
+---
+layout: page
+title: cloud.gov federalist
+permalink: /federalist/
+---
+
+
+<div class="features-page">
+  <div class="usa-grid mb-lg">
+    <div class="usa-width-two-thirds">
+      <h1>
+        Less work.<br>
+        More Federalist.
+      </h1>
+      <p>We’ve taken the work out of launching a compliant federal website.</p>
+    </div>
+    <div class="usa-width-one-third usa-hero-callout">
+      <h2>Try it for free</h2>
+      <p>Contact us to try Federalist temporarily on a prototype or test project.</p>
+      <a class="usa-button" href="mailto:federalist-inquiries@gsa.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20federalist:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A"> Get in touch</a>
+    </div>
+  </div>
+
+  <div class="usa-grid mb-lg">
+    <hr class="hr-light">
+  </div>
+
+  <div class="usa-grid">
+    <section class="info-block">
+      <div class="usa-width-one-whole">
+        <h1>Features</h1>
+        <br>
+        <div class="usa-grid-full">
+          <div class="usa-width-one-third">
+            <div class="feature-group vertical">
+              <div class="feature-image small">
+                <img alt="rocket icon" src="{{site.baseurl}}/assets/images/icons/icon-rocket-color.svg">
+              </div>
+              <div class="feature-text">
+                <h5>Deploy quickly</h5>
+                <p>If your code is already on GitHub, Federalist can securely deploy a website from your repository in minutes.</p>
+              </div>
+            </div>
+          </div>
+          <div class="usa-width-one-third">
+            <div class="feature-group vertical">
+              <div class="feature-image small">
+                <img alt="layout icon"  src="{{site.baseurl}}/assets/images/icons/icon-layout-color.svg">
+              </div>
+              <div class="feature-text">
+                <h5>Accessible templates</h5>
+                <p><a href="https://federalist.18f.gov/pages/using-federalist/templates/">Our 508-compliant website templates</a> help you kickstart your design process.</p>
+              </div>
+            </div>
+          </div>
+          <div class="usa-width-one-third">
+            <div class="feature-group vertical">
+              <div class="feature-image small">
+                <img alt="badge icon" src="{{site.baseurl}}/assets/images/icons/icon-badge-color.svg">
+              </div>
+              <div class="feature-text">
+                <h5>Customization</h5>
+                <p>Use a site generator like Jekyll, Hugo, Gatsby, or other tools to deploy custom site designs through Federalist.</p>
+              </div>
+            </div>
+          </div>
+         </div>
+        <div class="usa-grid-full">
+          <div class="usa-width-one-third">
+            <div class="feature-group vertical">
+              <div class="feature-image small">
+                <img alt="clock icon" src="{{site.baseurl}}/assets/images/icons/icon-clockback-color.svg">
+              </div>
+              <div class="feature-text">
+                <h5>Simple version control</h5>
+                <p>Use GitHub, a web-based hosting service with built-in version control, for real-time publishing and easy collaboration.</p>
+              </div>
+            </div>
+          </div>
+          <div class="usa-width-one-third">
+            <div class="feature-group vertical">
+              <div class="feature-image small">
+                <img alt="two squares icon" src="{{site.baseurl}}/assets/images/icons/icon-two-squares-color.svg">
+              </div>
+              <div class="feature-text">
+                <h5>Reusable and public</h5>
+                <p>Federalist source code is open source and in the public domain. Share code with other agencies and vendors also using Federalist.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+
+  <div class="usa-grid">
+    <br>
+    <hr class="hr-light">
+  </div>
+
+  <div class="usa-grid mb-xxl">
+    <section class="info-block">
+      <a id="page-body"></a>
+      <h1>It’s easy to get started.</h1>
+      <div class="usa-grid-full feature-group">
+        <div class="usa-width-one-half">
+          <div class="criteria-list">
+            <h5 class="criteria-list-heading">We’ve streamlined our onboarding process.</h5>
+            <ul class="checklist copy">
+              <li>Execute an Interagency Agreement in weeks.</li>
+              <li>Unlimited storage and bandwidth for your sites.</li>
+              <li>Unlimited sites for your team.</li>
+              <li>Federalist’s content delivery network seamlessly keeps your site up and running even when traffic spikes.</li>
+              <li>No hidden charges.</li>
+            </ul>
+            <h5 class="criteria-list-heading">Customize and publish your site with confidence.</h5>
+            <ul class="checklist copy">
+              <li>Ensure that content is tested and reviewed before publication.</li>
+              <li>Preview site changes before making them live.</li>
+              <li>Collaborate with colleagues to edit and review your site.</li>
+              <li>Make site updates quickly.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="usa-width-one-half">
+          <div class="criteria-list">
+            <h5 class="criteria-list-heading">Federally compliant from the start</h5>
+            <ul class="checklist copy">
+              <li>We are built on the FedRAMP-certified cloud.gov platform and Amazon Web Services GovCloud infrastructure.</li>
+              <li>Your agency can use our Authority to Operate (ATO).</li>
+              <li>Protected by multiple levels of authentication.</li>
+              <li>We handle vulnerability scanning and penetration testing for you.</li>
+            </ul>
+            <h5 class="criteria-list-heading">Easy to change content and code</h5>
+            <ul class="checklist copy">
+              <li>Deploy content and code quickly and safely, all while under your control.</li>
+              <li>Move your sites on or off of Federalist at any time.</li>
+              <li>Closed-source software may require expensive training to learn.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div class="usa-grid mb-lg">
+    <hr class="hr-light"/>
+  </div>
+
+  <div class="usa-grid mt-md">
+    <h1>We’re here to help.</h1>
+    <div class="flexbox-grid">
+      <div class="usa-width-one-third flexbox-item">
+        <p class="medium-copy">Try a free test site to see if Federalist is right for you.</p>
+        <a class="usa-button callout-inline" href="mailto:federalist-inquiries@gsa.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20federalist:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A">Get in touch</a>
+      </div>
+      <div class="usa-width-one-third flexbox-item">
+        <p class="medium-copy">Join our Slack community to connect and learn from other Federalist users across the federal government. <i>(Requires access to Google services, if you cannot access this form, please reach out via <a href="mailto:federalist-inquiries@gsa.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20federalist:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A">email</a>)</i></p>
+        <a class="usa-button" href="https://chat.18f.gov/">Join the Slack channel</a>
+      </div>
+      <div class="usa-width-one-third flexbox-item">
+        <p class="medium-copy">The Federalist team wants to learn from your experience so we can improve the product for all our users.</p>
+        <a class="usa-button" href="mailto:federalist-inquiries@gsa.gov">Share your feedback</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_pages/cloud-gov-platform.md
+++ b/_pages/cloud-gov-platform.md
@@ -1,0 +1,63 @@
+---
+layout: page
+title: cloud.gov platform
+permalink: /platform/
+---
+
+
+As a Platform as a Service, cloud.gov is responsible for maintenance and security of the cloud.gov platform. Customers are responsible for maintenance and security of their custom code running on the platform.
+
+Here's a chart to illustrate this in three example use cases:
+
+{% asset boundaries.svg alt="Diagram of responsibilities, described in text below" width="450" %}
+
+<!-- Source for this diagram is https://docs.google.com/drawings/d/1UBiOteSPXpA72KE52Kh-j7aYr73zTkzJ_oMuw5F293I/edit -->
+
+App #1 uses a standard buildpack. (A buildpack provides support for a programming language.) The customer is only responsible for the app code and its dependencies.
+
+App #2 uses a custom buildpack, so the customer's responsibility expands from the app code to managing the custom buildpack and its dependencies. If you choose to use a custom buildpack, you are responsible for:
+
+* Ensuring your application framework/runtime and all dependencies are supported versions with no known vulnerabilities.
+* Continually updating your runtime and dependencies as new vulnerabilities are discovered and fixed.
+* Maintaining a best practice baseline configuration for your application framework/runtime that meets all applicable security standards.
+
+App #3 is a Docker setup, where the customer is fully responsible for their Docker container and custom image. Learn about this feature.
+
+cloud.gov is always responsible for the following components at its platform level:
+
+* Operating system
+* Continuous monitoring
+* Anti-malware
+* Network security
+* Versioning
+* Scaling
+* Logging
+* Alerting
+
+## Deprecation policy
+
+From time to time, it becomes necessary to deprecate a service, feature, or API. Below is our policy for doing so. In the description, `service`
+refers to a service, feature, API, etc.
+
+In cases where a replacement service will be provided, we'll make the replacement service available before beginning the deprecation process.
+Deprecations happen in steps:
+
+1. We send an email to all customers letting them know the service is being deprecated.
+1. At least 30 days after the initial email, we stop allowing new instances of the deprecated service, but continue allowing existing instances to work.
+1. Every two weeks after we stop allowing new instances of the deprecated service, we email customers who are still using the deprecated service.
+1. At least 150 days after the initial email, we shut down existing instances of deprecated service.
+
+
+Here's an example:
+
+First, cloud.gov determines that the coffee service is not serving customers as well as a new espresso service might, and we decide
+to replace the coffee service entirely with the espresso service.
+First, we make the espresso service generally available. Next, we send out the general announcement to all of our users. This announcement goes out on April 3rd and states:
+
+- the coffee service is being deprecated
+- the replacement is the espresso service
+- as of May 3rd (30 days after April 3rd), no new instances of the coffee service will be created
+- as of August 31st (150 days after April 3rd), existing instances of the coffee service will be shut down
+
+After May 3rd, we begin sending emails to users still using the coffee service, at least one message every other week.
+Finally, on August 31st, we shut down the last instances of the coffee service.

--- a/_pages/get-started.md
+++ b/_pages/get-started.md
@@ -1,11 +1,7 @@
 ---
-parent: pricing
 layout: page
-sidenav: true
-title: Try a free sandbox space
-redirect_from:
-  - /overview/pricing/free-limited-sandbox/
-  - /docs/pricing/free-limited-sandbox/
+title: Get started
+permalink: /get-started/
 ---
 
 A sandbox is a free space that you can use to see if cloud.gov might suit your team’s needs. From the setup process through deploying an app, it works similarly to other spaces that are included in [paid access packages]({{ site.baseurl }}/pricing/), with [some limitations](#sandbox-limitations).

--- a/_pages/overiew.md
+++ b/_pages/overiew.md
@@ -14,7 +14,7 @@ redirect_from:
 
 If you're interested in using cloud.gov, email [**inquiries@cloud.gov**](mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F). We’ll schedule a call to answer your questions and help you [get started]({{ site.baseurl }}{% link _pages/sign-up.md %}).
 
-If you have a U.S. federal government email address, you can [get access to a free sandbox space]({{ site.baseurl }}{% link _pages/free-limited-sandbox.md %}).
+If you have a U.S. federal government email address, you can [get access to a free sandbox space]({{ site.baseurl }}{% link _pages/get-started.md %}).
 
 ### Support for people who use cloud.gov
 

--- a/_pages/overiew.md
+++ b/_pages/overiew.md
@@ -1,14 +1,20 @@
 ---
 layout: page
-title: Contact
-permalink: /contact/
+title: Overview
+permalink: /overview/
+redirect_from:
+  - /docs/overview/what-is-cloudgov/
+  - /overview/overview/what-is-cloudgov/
+  - /docs/intro/overview/what-is-cloudgov
+  - /intro/overview/what-is-cloudgov
+  - /docs
 ---
 
 ### Want to use cloud.gov?
 
-If you're interested in using cloud.gov, email [**inquiries@cloud.gov**](mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F). We’ll schedule a call to answer your questions and help you get started.
+If you're interested in using cloud.gov, email [**inquiries@cloud.gov**](mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F). We’ll schedule a call to answer your questions and help you [get started]({{ site.baseurl }}{% link _pages/sign-up.md %}).
 
-If you have a U.S. federal government email address, you can get access to a free sandbox space.
+If you have a U.S. federal government email address, you can [get access to a free sandbox space]({{ site.baseurl }}{% link _pages/free-limited-sandbox.md %}).
 
 ### Support for people who use cloud.gov
 

--- a/_pages/procurement.md
+++ b/_pages/procurement.md
@@ -1,0 +1,9 @@
+---
+title: Procurement
+layout: page
+sidenav: false
+---
+
+## Procurement
+
+Info for perspective customers that is relevant and clearly stated.

--- a/_pages/security-and-compliance.md
+++ b/_pages/security-and-compliance.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Security and compliance
+permalink: /security-and-compliance/
+redirect_from:
+  - /docs/overview/cloudgov-benefits/
+  - /docs/overview/fedramp-tracker/
+  - /docs/security/conforming-federal-security-regulations/
+---
+
+
+# TBD
+
+cloud.gov has a [Provisional Authority to Operate (P-ATO) at the Moderate impact level from the FedRAMP Joint Authorization Board (JAB)](https://marketplace.fedramp.gov/#!/product/18f-cloudgov). This means cloud.gov has undergone a significant, thorough security and compliance review so that your agency can focus on reviewing the parts of the system that serve your mission more directly.
+
+## What is a P-ATO?
+
+The **[Federal Risk and Authorization Management Program (FedRAMP)](https://www.fedramp.gov/)** evaluates cloud services and issues a **Provisional Authority to Operate (P-ATO)** to those that pass review. Those come in two flavors: Agency and JAB. Both authorizations [look at a standardized set of FISMA and NIST requirements](https://www.fedramp.gov/jab-or-agency-how-do-i-get-a-fedramp-ato/) and both can be used by other agencies in their ATO process. The difference is, when the **Joint Authorization Board (JAB)** is convened, it's to review a cloud service that is and should be used throughout the government. The members of the JAB are the CIOs of the General Services Administration, Department of Defense, and Department of Homeland Security. They issue [a P-ATO for cloud services that pass their review and to be used to run systems holding any kind of government data at specific levels](https://marketplace.fedramp.gov/#!/products?status=Compliant&sort=productName&authorizationType=JAB). cloud.gov has an **authorization at the moderate level** which means it is a vetted and trustable service for data where [the impact of loss is limited or serious — but not catastrophic](http://csrc.nist.gov/publications/fips/fips199/FIPS-PUB-199-final.pdf#page=6).
+
+Once that P-ATO is granted, FedRAMP requires cloud.gov to undergo re-assessment every year and maintain continuous monitoring. This gives your agency ongoing assurance that cloud.gov is compliant.
+
+*For DoD teams:* the Defense Information Systems Agency (DISA) categorizes [FedRAMP Moderate as equivalent to DISA impact level two](https://dl.dod.cyber.mil/wp-content/uploads/cloud/pdf/Cloud_Computing_SRG_v1r3.pdf) (IL2) and they have issued a DoD Provisional Authorization for cloud.gov at DISA impact level two. Some points to bear in mind:
+
+* The FedRAMP package (see below) includes the DISA Provisional Authorization (PA) letter for your reference.
+* Per the PA and the [DoD Cloud Computing SRG](https://dl.dod.cyber.mil/wp-content/uploads/cloud/SRG/index.html), the artifacts available to an Authorizing Official (AO) are those included in the FedRAMP-approved package. The Cloud Computing SRG has a useful illustration to that effect, [DoD Continuous Monitoring for CSOs with a FedRAMP JAB PA](https://dl.dod.cyber.mil/wp-content/uploads/cloud/SRG/index.html#_Fig4)
+* To meet the intent of OMB and DoD policies that cloud authorization follow a "do once, use many times" framework, cloud.gov will not provide artifacts that are already encompassed by the FedRAMP authorization and continuous monitoring program.
+
+## How you can use this P-ATO
+
+Your agency still needs to grant your system an Authority to Operate, but FedRAMP has done the labor-intensive work of reviewing cloud.gov's security posture and endorsed it, which reduces the compliance work you need to do. Your agency's authorizing official can request the P-ATO documentation package from FedRAMP and accept that endorsement for your own system.
+
+Here's how it works: Every moderate-impact federal system is required to account for a baseline of at least 261 controls (your agency may have additional controls) before it can be granted an ATO. The cloud.gov platform provides you with 155 fully or partially inheritable controls. Once cloud.gov's P-ATO is reviewed and accepted, many of those requirements are already implemented and documented. Responsibility for most of the remaining requirements are shared between cloud.gov and your application, and only a limited number are fully yours.
+
+Here's an example of a control breakdown for a simple moderate-impact system hosted on cloud.gov:
+
+{% asset fedramp-moderate-controls-new.png alt="Graphic showing the breakdown of how many controls are fully covered by cloud.gov." %}
+
+The [**Control Implementation Summary + Customer Responsibility Matrix + Control-by-Control Inheritance (.xlsx)**]({{ site.baseurl }}/resources/cloud.gov-CIS-Worksheet.xlsx) (last updated December 9, 2020) is a summary of each Low and Moderate security control and whether it is handled by cloud.gov, shared responsibility, or customer responsibility. It includes guidance on which controls a customer system can fully or partially inherit from cloud.gov.
+
+## Start the ATO process
+
+If you want to authorize cloud.gov, [**request the P-ATO documentation package from FedRAMP**](https://www.fedramp.gov/assets/resources/documents/Agency_Package_Request_Form.pdf) (the Package ID for that form is F1607067912). You can also view the [FedRAMP Marketplace page for cloud.gov](https://marketplace.fedramp.gov/#/product/18f-cloudgov?sort=productName).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "bundle exec jekyll build",
     "clean": "bundle exec jekyll clean",
-    "develop": "bundle exec jekyll serve -I",
+    "develop": "bundle exec jekyll serve -I --profile",
     "reset": "npx rimraf .git",
     "start": "bundle exec jekyll serve",
     "test": "bundle exec htmlproofer _site; npx a11y '_site/**/*.html'"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add initial pages to stub out for future content and design updates.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-placeholder-pages)

## Security Considerations
None
